### PR TITLE
Define tool capabilities accoring to to new spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,17 @@ import { registerAllTools } from "./tools/register.js";
 async function initializeServer() {
 
   const server = new McpServer({
-    name: "sanity",
-    version: "1.0.0",
-  });
+      name: "sanity",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {
+          listChanged: false
+        }
+      }
+    }
+  );
 
   // Initialize Tools
   registerAllTools(server);


### PR DESCRIPTION
From [new spec](https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#capabilities) :
- "Servers that support tools MUST declare the tools capability"