### PR TITLE
Add autoGenerateArrayKeys to document creation

### DIFF
--- a/src/tools/documents/mutations/createDocument.ts
+++ b/src/tools/documents/mutations/createDocument.ts
@@ -14,7 +14,7 @@ export async function createDocumentTool(
     const { document } = args;
     
     // Create the document using the sanity client
-    const result = await sanityClient.create(document);
+    const result = await sanityClient.create(document, { autoGenerateArrayKeys: true });
     const text = JSON.stringify({
       operation: "create",
       document: result

--- a/src/tools/documents/mutations/createMultipleDocuments.ts
+++ b/src/tools/documents/mutations/createMultipleDocuments.ts
@@ -20,12 +20,16 @@ export async function createMultipleDocumentsTool(
       transaction.create(doc);
     });
     
-    // Commit the transaction with the provided options
-    const result = await transaction.commit(options || {});
+    // Commit the transaction with autoGenerateArrayKeys enabled and any additional options
+    const result = await transaction.commit({
+      autoGenerateArrayKeys: true,
+      ...options
+    });
+    
     const text = JSON.stringify({
       operation: "create_multiple",
       documentsCount: documents.length,
-      options,
+      options: { autoGenerateArrayKeys: true, ...options },
       result
     }, null, 2);
     


### PR DESCRIPTION
This adds a `_key` attribute to array items automatically based on the client option autoGenerateArrayKeys, which is required to ensure it can be addressed uniquely in a real-time collaboration context.