### PR TITLE
Add SANITY_PERSPECTIVE to .env config. Make 'drafts' as the default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ To connect Claude Desktop to this MCP server, your configuration should look lik
         "SANITY_DATASET": "",
         "SANITY_API_TOKEN": "",
         "SANITY_API_HOST": "https://api.sanity.io",
-        "SANITY_API_VERSION": "vX"
+        "SANITY_API_VERSION": "vX",
+        "SANITY_PERSPECTIVE": "drafts"
       }
     }
   }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,6 +8,10 @@ const envSchema = z.object({
   SANITY_DATASET: z.string().describe("The dataset"),
   SANITY_API_VERSION: z.string().describe("Sanity API version"),
   SANITY_API_HOST: z.string().describe("Sanity API host"),
+  SANITY_PERSPECTIVE: z.union([
+    z.enum(['published', 'drafts', 'raw']),
+    z.array(z.string())
+  ]).optional().default('drafts').describe("Sanity perspective - can be 'published', 'drafts', 'raw' or an array of release IDs."),
 });
 
 export const env = envSchema.safeParse(process.env);

--- a/src/config/sanity.ts
+++ b/src/config/sanity.ts
@@ -13,4 +13,5 @@ export const sanityClient = createClient({
   apiVersion: env.data.SANITY_API_VERSION,
   token: env.data.SANITY_API_TOKEN,
   useCdn: false,
+  perspective: env.data.SANITY_PERSPECTIVE // This defaults to 'drafts' if not set in env
 });


### PR DESCRIPTION
This makes the default perspective to be `drafts` for all servers.

In endpoints that require other perspectives we could use:
```typescript
const client = sanityClient.withConfig({
  perspective: 'published'
});
```