### PR TITLE
Refactor GROQ query execution types and schemas

### DIFF
--- a/src/tools/groq/executeGroqQuery.ts
+++ b/src/tools/groq/executeGroqQuery.ts
@@ -1,9 +1,6 @@
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
-import type { z } from "zod";
 import { sanityClient } from "../../config/sanity.js";
-import type { ExecuteGroqQuerySchema } from "./schemas.js";
-
-type ExecuteGroqQueryParams = z.infer<typeof ExecuteGroqQuerySchema>;
+import { ExecuteGroqQueryParams } from "./schemas.js";
 
 /**
  * Tool for executing arbitrary GROQ queries against the Sanity dataset

--- a/src/tools/groq/schemas.ts
+++ b/src/tools/groq/schemas.ts
@@ -71,3 +71,8 @@ export const executeGroqQueryParams = {
  * Zod schema for execute_groq_query tool parameters
  */
 export const ExecuteGroqQuerySchema = z.object(executeGroqQueryParams); 
+
+/**
+ * Type for execute_groq_query tool parameters
+ */
+export type ExecuteGroqQueryParams = z.infer<typeof ExecuteGroqQuerySchema>;


### PR DESCRIPTION
- Moved ExecuteGroqQueryParams type definition to schemas.ts