### PR TITLE
feat: get initial context

### DIFF
--- a/src/tools/context/getInitialContextTool.ts
+++ b/src/tools/context/getInitialContextTool.ts
@@ -1,0 +1,60 @@
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { sanityClient } from "../../config/sanity.js";
+import { getDatasetsTool } from "../datasets/getDatasetsTool.js";
+import { listSchemaTypesTool } from "../schema/listSchemaTypesTool.js";
+import { listEmbeddingsIndicesTool } from "../embeddings/listEmbeddingsTool.js";
+import { listAllReleases } from "../releases/listReleaseDocuments.js";
+import { getSanityConfigTool } from "../config/getSanityConfigTool.js";
+
+let contextInitialized = false;
+
+export function hasInitialContext(): boolean {
+  return contextInitialized;
+}
+
+export async function getInitialContextTool(
+  args: {},
+  extra: RequestHandlerExtra
+) {
+  try {
+    const config = await getSanityConfigTool({}, extra);
+    const datasets = await getDatasetsTool({}, extra);
+    const schemaTypes = await listSchemaTypesTool({}, extra);
+    const embeddings = await listEmbeddingsIndicesTool({}, extra);
+    //TODO: only active releases should be listed
+    const releases = await listAllReleases();
+
+    contextInitialized = true;
+
+    const outputText = `Sanity MCP Server:
+
+CONFIG & DATASETS
+${config.content[0].text}
+${datasets.content[0].text}
+
+SCHEMA TYPES: ${schemaTypes.content[0].text}
+
+EMBEDDINGS: ${embeddings.content[0].text}
+
+RELEASES: ${releases.content[0].text}`;
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: outputText,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text" as const,
+          text: `Error getting context: ${error}`,
+        },
+      ],
+    };
+  }
+}

--- a/src/tools/context/middleware.ts
+++ b/src/tools/context/middleware.ts
@@ -1,0 +1,18 @@
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { hasInitialContext } from "./getInitialContextTool.js";
+
+export function enforceInitialContextMiddleware(
+  toolName: string,
+  args: any,
+  extra: RequestHandlerExtra
+) {
+  if (toolName === "get_initial_context") {
+    return;
+  }
+
+  if (!hasInitialContext()) {
+    throw new Error(
+      "Initial context has not been retrieved. Please call get_initial_context tool first to get the initial context."
+    );
+  }
+}

--- a/src/tools/context/register.ts
+++ b/src/tools/context/register.ts
@@ -1,0 +1,11 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getInitialContextTool } from "./getInitialContextTool.js";
+
+export function registerContextTools(server: McpServer) {
+  server.tool(
+    "get_initial_context",
+    "IMPORTANT: This tool must be called before using any other tools. It will get initial context and usage instructions for this MCP server. ",
+    {},
+    getInitialContextTool
+  );
+}

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { registerConfigTools } from "./config/register.js";
 import { registerGroqTools } from "./groq/register.js";
 import { registerVersionTools } from "./version/register.js";
@@ -8,19 +9,55 @@ import { registerSchemaTools } from "./schema/register.js";
 import { registerDatasetsTools } from "./datasets/register.js";
 import { registerReleasesTools } from "./releases/register.js";
 import { registerEmbeddingsTools } from "./embeddings/register.js";
+import { registerContextTools } from "./context/register.js";
+import { enforceInitialContextMiddleware } from "./context/middleware.js";
+
+function createContextCheckingServer(server: McpServer): McpServer {
+  const originalTool = server.tool;
+  return new Proxy(server, {
+    get(target, prop) {
+      if (prop === "tool") {
+        return function (this: any, ...args: any[]) {
+          const [name, description, schema, handler] = args;
+
+          const wrappedHandler = async (
+            args: any,
+            extra: RequestHandlerExtra
+          ) => {
+            enforceInitialContextMiddleware(name, args, extra);
+            return handler(args, extra);
+          };
+
+          return originalTool.call(
+            this,
+            name,
+            description,
+            schema,
+            wrappedHandler
+          );
+        };
+      }
+      return (target as any)[prop];
+    },
+  });
+}
 
 /**
  * Register all tools with for the MCP server
  */
 export function registerAllTools(server: McpServer) {
-  //registerExampleTools(server);
-  registerConfigTools(server);
-  registerGroqTools(server);
-  registerVersionTools(server);
-  registerDocumentTools(server);
-  registerProjectsTools(server);
-  registerSchemaTools(server);
-  registerDatasetsTools(server);
-  registerReleasesTools(server);
-  registerEmbeddingsTools(server);
+  // Create a proxy server that adds initial context check to all tools
+  const wrappedServer = createContextCheckingServer(server);
+
+  //registerExampleTools(wrappedServer);
+  registerContextTools(wrappedServer);
+  registerConfigTools(wrappedServer);
+  registerGroqTools(wrappedServer);
+  registerVersionTools(wrappedServer);
+  registerDocumentTools(wrappedServer);
+  registerProjectsTools(wrappedServer);
+  registerSchemaTools(wrappedServer);
+  registerDatasetsTools(wrappedServer);
+  registerReleasesTools(wrappedServer);
+  registerEmbeddingsTools(wrappedServer);
 }

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -46,10 +46,8 @@ function createContextCheckingServer(server: McpServer): McpServer {
  * Register all tools with for the MCP server
  */
 export function registerAllTools(server: McpServer) {
-  // Create a proxy server that adds initial context check to all tools
   const wrappedServer = createContextCheckingServer(server);
 
-  //registerExampleTools(wrappedServer);
   registerContextTools(wrappedServer);
   registerConfigTools(wrappedServer);
   registerGroqTools(wrappedServer);

--- a/src/tools/releases/listReleaseDocuments.ts
+++ b/src/tools/releases/listReleaseDocuments.ts
@@ -1,10 +1,12 @@
 import { SanityClient } from "@sanity/client";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { sanityClient } from "../../config/sanity.js";
-
-export async function listAllReleases(): Promise<CallToolResult> {
+import { ListReleaseDocumentsParamsType } from "./schema.js";
+export async function listAllReleases(
+  args: ListReleaseDocumentsParamsType
+): Promise<CallToolResult> {
   try {
-    let res = await listReleases(sanityClient);
+    let res = await listReleases(sanityClient, args.includeAll);
     if (!res) {
       return {
         content: [
@@ -40,8 +42,11 @@ export async function listAllReleases(): Promise<CallToolResult> {
 }
 export async function listReleases(
   client: SanityClient,
+  includeAll: boolean = false
 ): Promise<Record<string, string>[]> {
-  const query = "releases::all()";
+  const query = includeAll
+    ? "releases::all()"
+    : 'releases::all()[state == "active"]';
   const params = {};
 
   try {

--- a/src/tools/releases/register.ts
+++ b/src/tools/releases/register.ts
@@ -7,6 +7,7 @@ import {
   UnpublishDocument,
   UnpublishMultipleDocuments,
   Release,
+  ListReleaseDocumentsParams,
 } from "./schema.js";
 import { unpublishDocumentFromRelease } from "./unpublishDocumentFromRelease.js";
 import { addMultipleDocumentsToRelease } from "./addMultipleDocumentsToRelease.js";
@@ -48,5 +49,6 @@ export function registerReleasesTools(server: McpServer) {
     "list_release_documents",
     "List all releases documents",
     listAllReleases,
+    listAllReleases
   );
 }

--- a/src/tools/releases/register.ts
+++ b/src/tools/releases/register.ts
@@ -48,7 +48,7 @@ export function registerReleasesTools(server: McpServer) {
   server.tool(
     "list_release_documents",
     "List all releases documents",
-    listAllReleases,
+    ListReleaseDocumentsParams,
     listAllReleases
   );
 }

--- a/src/tools/releases/schema.ts
+++ b/src/tools/releases/schema.ts
@@ -3,6 +3,24 @@ import { z } from "zod";
 // Define the release type enum values
 const ReleaseType = z.enum(["asap", "undecided", "scheduled"]);
 
+export const ListReleaseDocumentsParams = {
+  includeAll: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      "If true, list all releases, otherwise list only active releases"
+    ),
+};
+
+export const ListReleaseDocumentsParamsSchema = z.object(
+  ListReleaseDocumentsParams
+);
+
+export type ListReleaseDocumentsParamsType = z.infer<
+  typeof ListReleaseDocumentsParamsSchema
+>;
+
 // Define the metadata schema
 const ReleaseMetadata = z
   .object({

--- a/src/tools/schema/listSchemaTypesTool.ts
+++ b/src/tools/schema/listSchemaTypesTool.ts
@@ -6,26 +6,14 @@ export async function listSchemaTypesTool(
   extra: RequestHandlerExtra
 ) {
   try {
-    const query = `array::unique(*[]._type)`;
-    const types = await sanityClient.fetch(query);
-
-    if (!Array.isArray(types)) {
-      throw new Error("Unexpected response format: expected an array.");
-    }
-
-    const userTypes = types.filter(
-      (type) =>
-        typeof type === "string" &&
-        !type.startsWith("system.") &&
-        !type.startsWith("sanity.")
-    );
+    const schemaTypes = await getSchemaTypes();
 
     return {
       content: [
         {
           type: "text" as const,
-          text: userTypes.length
-            ? `Schema types: ${userTypes.join(", ")}`
+          text: schemaTypes.length
+            ? `Schema types: ${schemaTypes.join(", ")}`
             : "No custom schema types found.",
         },
       ],
@@ -40,5 +28,27 @@ export async function listSchemaTypesTool(
         },
       ],
     };
+  }
+}
+
+export async function getSchemaTypes() {
+  try {
+    const query = `array::unique(*[]._type)`;
+    const types = await sanityClient.fetch(query);
+
+    if (!Array.isArray(types)) {
+      throw new Error("Unexpected response format: expected an array.");
+    }
+
+    const userTypes = types.filter(
+      (type) =>
+        typeof type === "string" &&
+        !type.startsWith("system.") &&
+        !type.startsWith("sanity.")
+    );
+
+    return userTypes;
+  } catch (error) {
+    throw new Error(`Error fetching schema types: ${error}`);
   }
 }


### PR DESCRIPTION
This PR adds getInitialContextTool that is being called at the start of the history. 
Context returns following data:
- config
- datasets
- schema
- embeddings
- active releases

Did some cleanup in this PR as well, and split up schema functions as well as updated list releases function to return active releases as default