### PR TITLE
handle release id prefix in request and search for drafts if publishe…

### DIFF
--- a/src/tools/releases/addDocumentToRelease.ts
+++ b/src/tools/releases/addDocumentToRelease.ts
@@ -7,13 +7,25 @@ import { ReleaseDocumentParamsType } from "./schema.js";
 import { sanityClient } from "../../config/sanity.js";
 import { addDocVersionId, DocumentCategory, parseDocId } from "../utils.js";
 
+function parseReleaseId(releaseId: string): string {
+  const res = releaseId.split(".");
+  if (res.length == 1) {
+    return releaseId;
+  }
+  return res.at(-1)!!;
+}
+
 export async function processDocumentForRelease(
   params: ReleaseDocumentParamsType,
 ): Promise<addDocumentRequest> {
   let { publishedId, releaseId } = params;
-  const doc = await sanityClient.getDocument(publishedId);
+  var doc = await sanityClient.getDocument(publishedId);
   if (doc === undefined) {
-    throw Error(`document with publishedId: ${publishedId}, not found`);
+    // check for a draft version if no published version is found
+    doc = await sanityClient.getDocument(`drafts.${publishedId}`);
+    if (doc === undefined) {
+      throw Error(`document with publishedId: ${publishedId}, not found`);
+    }
   }
   // gets the published id from the document if its in draft we still used the id as drafts.<published_id>
   // if tho its not published yet
@@ -23,8 +35,10 @@ export async function processDocumentForRelease(
     throw Error("publishedId should not contain release information");
   }
 
+  const parsedReleaseId = parseReleaseId(releaseId);
+
   // adds the versions id to the doc i.e. versions.<releaseId>.<publishedId>
-  doc._id = addDocVersionId(docReleaseId, releaseId);
+  doc._id = addDocVersionId(docReleaseId, parsedReleaseId);
   return {
     actionType: "sanity.action.document.version.create",
     publishedId: docReleaseId,


### PR DESCRIPTION
### 🐛 Remove releases prefix from release id 
Also search for drafts version if published versions is not found in add document to release