### PR TITLE
fix: handle potentially missing schema. Fixes #28

### DIFF
--- a/src/tools/schema/getSchemaOverviewTool.ts
+++ b/src/tools/schema/getSchemaOverviewTool.ts
@@ -63,9 +63,9 @@ export async function getSchemaOverview({
     },
   );
 
-  let schema = JSON.parse(schemaString) as ManifestSchemaType[];
+  let schema = JSON.parse(schemaString) as ManifestSchemaType[] | null;
 
-  schema = schema.filter((documentOrObject) =>
+  schema = (schema ?? []).filter((documentOrObject) =>
     ["sanity.", "assist."].every(
       (prefix) => !documentOrObject.type.startsWith(prefix),
     ),


### PR DESCRIPTION
```typescript
const schemaString: string = await sanityClient.fetch(
    "*[_id == $schemaId][0].schema",
    {
      schemaId: schemaId ?? "sanity.workspace.schema.default",
    },
  );
```

The query that attempts to fetch schema manifest from dataset may return `null` if schema have not been stored in the dataset. This leads to errors in mcp clients using this tool in that scenario.

```text
Error getting context: TypeError: Cannot read properties of null (reading 'filter')
```