### PR TITLE
Update codeowners to reflect ownership post-stunt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @haakonjacobsen @selbekk @natashatikhonova @FredrikMorstad
+* @RostiMelk


### PR DESCRIPTION
This PR removes the temporary team from the CODEOWNERS file, and adds @RostiMelk. Other Sanity people should probably be added in the future, or one could create a Github team to avoid changing this in the future.