### PR TITLE
feat: validate patches, get fallbacks ++

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "chrono-node": "^2.8.0",
     "dotenv": "^16.4.7",
     "fast-xml-parser": "^5.2.0",
+    "lodash-es": "^4.17.21",
     "outdent": "^0.8.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@sanity/prettier-config": "^1.0.3",
+    "@types/lodash-es": "^4.17.12",
     "@types/minimist": "^1.2.5",
     "@types/node": "^22.13.11",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/mcp-server",
-  "version": "0.7.13",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/sanity-io/sanity-mcp-server"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       fast-xml-parser:
         specifier: ^5.2.0
         version: 5.2.0
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       outdent:
         specifier: ^0.8.0
         version: 0.8.0
@@ -36,6 +39,9 @@ importers:
       '@sanity/prettier-config':
         specifier: ^1.0.3
         version: 1.0.3(prettier@3.5.3)
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
@@ -178,6 +184,12 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.16':
+    resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -728,6 +740,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1265,6 +1280,12 @@ snapshots:
       '@types/node': 22.13.14
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.16
+
+  '@types/lodash@4.17.16': {}
 
   '@types/minimist@1.2.5': {}
 
@@ -1856,6 +1877,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
 

--- a/src/tools/documents/getDocumentTool.ts
+++ b/src/tools/documents/getDocumentTool.ts
@@ -1,0 +1,47 @@
+import {z} from 'zod'
+import {sanityClient} from '../../config/sanity.js'
+import {truncateDocumentForLLMOutput} from '../../utils/formatters.js'
+import {createSuccessResponse, withErrorHandling} from '../../utils/response.js'
+import {isDraftId, getPublishedId, getDraftId, type DocumentId} from '@sanity/id-utils'
+
+export const GetDocumentToolParams = z.object({
+  documentId: z.string().describe('The ID of the document to retrieve'),
+  perspective: z
+    .union([z.enum(['raw', 'drafts', 'published']), z.string()])
+    .optional()
+    .default('raw')
+    .describe('Perspective to query from: "raw", "drafts", "published", or a release ID'),
+})
+
+type Params = z.infer<typeof GetDocumentToolParams>
+
+async function tool(params: Params) {
+  const perspectiveClient = sanityClient.withConfig({
+    perspective: params.perspective ? [params.perspective] : 'raw',
+  })
+
+  const documentId = params.documentId as DocumentId
+  const alternateId = isDraftId(documentId) ? getPublishedId(documentId) : getDraftId(documentId)
+
+  // Fetch both the document and its alternative version in parallel
+  const [primaryDoc, alternateDoc] = await Promise.all([
+    perspectiveClient.getDocument(documentId).catch(() => null),
+    perspectiveClient.getDocument(alternateId).catch(() => null),
+  ])
+
+  const document = primaryDoc || alternateDoc
+
+  if (!document) {
+    return createSuccessResponse('Document not found', {
+      success: false,
+      message: `No document found with ID: ${params.documentId} or its published/draft equivalent in perspective: ${params.perspective}`,
+    })
+  }
+
+  return createSuccessResponse('Document retrieved successfully', {
+    success: true,
+    document: truncateDocumentForLLMOutput(document),
+  })
+}
+
+export const getDocumentTool = withErrorHandling(tool, 'Error retrieving document')

--- a/src/tools/documents/register.ts
+++ b/src/tools/documents/register.ts
@@ -6,6 +6,7 @@ import {patchDocumentTool, PatchDocumentToolParams} from './patchDocumentTool.js
 import {documentActionsTool, DocumentActionsToolParams} from './documentActionsTool.js'
 import {createVersionTool, CreateVersionToolParams} from './createVersionTool.js'
 import {discardVersionTool, DiscardVersionToolParams} from './discardVersionTool.js'
+import {getDocumentTool, GetDocumentToolParams} from './getDocumentTool.js'
 import {
   markVersionForUnpublishTool,
   MarkVersionForUnpublishParams,
@@ -32,6 +33,13 @@ export function registerDocumentsTools(server: McpServer) {
     'Apply direct patch operations to modify specific parts of a document without using AI generation',
     PatchDocumentToolParams.shape,
     patchDocumentTool,
+  )
+
+  server.tool(
+    'get_document',
+    'Retrieve a single document by ID from Sanity. Use this tool when you need to fetch a specific document by its ID. For multiple documents or complex queries, use query_documents instead.',
+    GetDocumentToolParams.shape,
+    getDocumentTool,
   )
 
   server.tool(

--- a/src/tools/documents/updateDocumentTool.ts
+++ b/src/tools/documents/updateDocumentTool.ts
@@ -2,7 +2,7 @@ import {z} from 'zod'
 import {sanityClient} from '../../config/sanity.js'
 import {truncateDocumentForLLMOutput} from '../../utils/formatters.js'
 import {createSuccessResponse, withErrorHandling} from '../../utils/response.js'
-import {type DocumentId, getPublishedId} from '@sanity/id-utils'
+import {type DocumentId, getDraftId, getPublishedId} from '@sanity/id-utils'
 import {getVersionId} from '@sanity/client/csm'
 import {schemaIdSchema} from '../schema/common.js'
 import type {GenerateInstruction} from '@sanity/client'
@@ -39,7 +39,7 @@ async function tool(params: Params) {
   const publishedId = getPublishedId(params.documentId as DocumentId)
   const documentId = params.releaseId
     ? getVersionId(publishedId, params.releaseId)
-    : params.documentId
+    : getDraftId(publishedId)
 
   const instructOptions: GenerateInstruction = {
     documentId,
@@ -56,7 +56,7 @@ async function tool(params: Params) {
 
     return createSuccessResponse('Document update initiated in background', {
       success: true,
-      document: {_id: params.documentId},
+      document: {_id: documentId},
     })
   }
 

--- a/src/tools/schema/common.ts
+++ b/src/tools/schema/common.ts
@@ -1,14 +1,5 @@
-import {outdent} from 'outdent'
 import {z} from 'zod'
-
-export const DEFAULT_SCHEMA_ID = 'sanity.workspace.schema.default'
-
-export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
-  Your Sanity schema has not been deployed. In your Sanity project, run the following command:
-  \`\`\`shell
-  SANITY_CLI_SCHEMA_STORE_ENABLED=true npx sanity@latest schema deploy
-  \`\`\`
-`
+import {DEFAULT_SCHEMA_ID} from '../../utils/manifest.js'
 
 export const schemaIdSchema = z
   .string()

--- a/src/tools/schema/listSchemaIdsTool.ts
+++ b/src/tools/schema/listSchemaIdsTool.ts
@@ -5,7 +5,14 @@ import {
   createErrorResponse,
   withErrorHandling,
 } from '../../utils/response.js'
-import {SCHEMA_DEPLOYMENT_INSTRUCTIONS} from './common.js'
+import {outdent} from 'outdent'
+
+export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
+  Your Sanity schema has not been deployed. In your Sanity project, run the following command:
+  \`\`\`shell
+  SANITY_CLI_SCHEMA_STORE_ENABLED=true npx sanity@latest schema deploy
+  \`\`\`
+`
 
 export const ListSchemaIdsToolParams = z.object({})
 

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,0 +1,18 @@
+import {sanityClient} from '../config/sanity.js'
+import type {ManifestSchemaType} from '../types/manifest.js'
+
+export const DEFAULT_SCHEMA_ID = 'sanity.workspace.schema.default'
+
+export async function getSchemaById(schemaId: string): Promise<ManifestSchemaType[]> {
+  const res = await sanityClient.fetch('*[_id == $schemaId][0]', {
+    schemaId,
+  })
+
+  if (!res.schema) {
+    throw new Error(
+      `Schema not found for id: ${schemaId}. Run list_schema_ids to find available schemas.`,
+    )
+  }
+
+  return JSON.parse(res.schema) as ManifestSchemaType[]
+}

--- a/src/utils/zod-sanity-schema.ts
+++ b/src/utils/zod-sanity-schema.ts
@@ -201,7 +201,7 @@ function convertImageType(): z.ZodTypeAny {
 }
 
 function createBlockContentSchema(_blockConfig: ManifestSchemaType): z.ZodTypeAny {
-  // Basic structure for block content
+  // TODO: Implement block content schema creation
   const blockSchema = z.object({
     _type: z.literal('block'),
     style: z.string(),

--- a/src/utils/zod-sanity-schema.ts
+++ b/src/utils/zod-sanity-schema.ts
@@ -1,0 +1,259 @@
+import {z} from 'zod'
+import {type DocumentId, getPublishedId} from '@sanity/id-utils'
+import type {ManifestArrayMember, ManifestField, ManifestSchemaType} from '../types/manifest.js'
+
+/**
+ * Creates a Zod schema from the Sanity schema array format
+ */
+export function createZodSchemaFromSanitySchema(sanitySchema: ManifestSchemaType[]) {
+  // Create a schema map for easier lookup
+  const schemaMap = sanitySchema.reduce<Record<string, ManifestSchemaType>>((acc, schema) => {
+    acc[schema.name] = schema
+    return acc
+  }, {})
+
+  // Build Zod schemas for each type
+  const zodSchemas: Record<string, z.ZodTypeAny> = {}
+
+  for (const schema of sanitySchema) {
+    zodSchemas[schema.name] = createZodTypeFromSanityType(schema, schemaMap, zodSchemas)
+  }
+
+  // Return a record of all schemas
+  return zodSchemas
+}
+
+/**
+ * Recursively creates Zod types from Sanity types
+ */
+function createZodTypeFromSanityType(
+  schema: ManifestSchemaType,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  // If we've already processed this schema, return the cached result
+  if (zodSchemas[schema.name]) {
+    return zodSchemas[schema.name]
+  }
+
+  // Create a placeholder to handle circular references
+  zodSchemas[schema.name] = z.lazy(() => createActualZodType(schema, schemaMap, zodSchemas))
+
+  return zodSchemas[schema.name]
+}
+
+/**
+ * Creates the actual Zod type based on the Sanity schema type
+ */
+function createActualZodType(
+  schema: ManifestSchemaType,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  switch (schema.type) {
+    case 'document':
+      return createDocumentSchema(schema, schemaMap, zodSchemas)
+
+    case 'object':
+      return createObjectSchema(schema, schemaMap, zodSchemas)
+
+    case 'array':
+      return createArraySchema(schema, schemaMap, zodSchemas)
+
+    default:
+      return convertBasicType(schema.type, false)
+  }
+}
+
+/**
+ * Creates a Zod document schema from a Sanity document schema
+ */
+function createDocumentSchema(
+  schema: ManifestSchemaType,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  const fields: Record<string, z.ZodTypeAny> = {
+    _id: z.string(),
+    _type: z.literal(schema.name),
+    _rev: z.string().optional(),
+    _createdAt: z.string().datetime().optional(),
+    _updatedAt: z.string().datetime().optional(),
+  }
+
+  if (schema.fields) {
+    for (const field of schema.fields) {
+      fields[field.name] = getFieldSchema(field, schemaMap, zodSchemas).optional()
+    }
+  }
+
+  return z.object(fields)
+}
+
+/**
+ * Creates a Zod object schema from a Sanity object schema
+ */
+function createObjectSchema(
+  schema: ManifestSchemaType,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  const fields: Record<string, z.ZodTypeAny> = {
+    _type: z.literal(schema.name),
+  }
+
+  if (schema.fields) {
+    for (const field of schema.fields) {
+      fields[field.name] = getFieldSchema(field, schemaMap, zodSchemas).optional()
+    }
+  }
+
+  return z.object(fields)
+}
+
+/**
+ * Creates a Zod array schema from a Sanity array schema
+ */
+function createArraySchema(
+  schema: ManifestSchemaType,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  if (!schema.of || schema.of.length === 0) {
+    return z.array(z.unknown())
+  }
+
+  const unionTypes = schema.of.map((item) => getFieldSchema(item, schemaMap, zodSchemas))
+  if (unionTypes.length < 2) {
+    return z.array(unionTypes[0] || z.unknown())
+  }
+
+  return z.array(z.union(unionTypes as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]))
+}
+
+/**
+ * Gets the appropriate Zod schema for a field
+ */
+function getFieldSchema(
+  field: ManifestField | ManifestArrayMember,
+  schemaMap: Record<string, ManifestSchemaType>,
+  zodSchemas: Record<string, z.ZodTypeAny>,
+): z.ZodTypeAny {
+  // First check if field.type is defined and a string
+  const fieldType = typeof field.type === 'string' ? field.type : undefined
+
+  // If it's a reference to another type in the schema
+  if (fieldType && schemaMap[fieldType]) {
+    return createZodTypeFromSanityType(schemaMap[fieldType], schemaMap, zodSchemas)
+  }
+
+  // Special case for block content
+  if (fieldType === 'block') {
+    return createBlockContentSchema(field as ManifestSchemaType)
+  }
+
+  // Array and object types need special handling
+  switch (fieldType) {
+    case 'array':
+      return createArraySchema(field as ManifestSchemaType, schemaMap, zodSchemas)
+    case 'object':
+      return createObjectSchema(field as ManifestSchemaType, schemaMap, zodSchemas)
+    case 'reference':
+      return convertReferenceType(true) // Pass true to use the transform for fields
+    case 'image':
+      return convertImageType()
+    default:
+      return convertBasicType(fieldType, true)
+  }
+}
+
+/**
+ * Shared helper for converting basic primitive types
+ */
+function convertBasicType(type: string | undefined, isField: boolean): z.ZodTypeAny {
+  switch (type) {
+    case 'string':
+      return z.string()
+    case 'text':
+      return z.string()
+    case 'url':
+      return z.string().url()
+    case 'datetime':
+      return z.string().datetime()
+    case 'slug':
+      return z.object({
+        current: z.string(),
+        _type: z.literal('slug'),
+      })
+    case 'reference':
+      return convertReferenceType(isField)
+    case 'image':
+      return convertImageType()
+    default:
+      return z.unknown()
+  }
+}
+
+/**
+ * Shared helper for converting reference types
+ */
+function convertReferenceType(transformId: boolean): z.ZodTypeAny {
+  const refSchema = z.string()
+
+  // Only apply the transform for field references, not for top-level schema types
+  const refWithTransform = transformId
+    ? refSchema.transform((id) => getPublishedId(id as DocumentId))
+    : refSchema
+
+  return z.object({
+    _ref: refWithTransform,
+    _type: z.literal('reference'),
+  })
+}
+
+/**
+ * Shared helper for converting image types
+ */
+function convertImageType(): z.ZodTypeAny {
+  return z.object({
+    _type: z.literal('image'),
+    asset: z.object({
+      _ref: z.string().regex(/^image-[a-zA-Z0-9]+(-\d+x\d+-[a-z]+)?$/, {
+        message:
+          "Image reference must be in the format 'image-[id]' or 'image-[id]-[dimensions]-[format]'",
+      }),
+      _type: z.literal('reference'),
+    }),
+  })
+}
+
+/**
+ * Creates a schema for Portable Text blocks
+ */
+function createBlockContentSchema(blockConfig: ManifestSchemaType): z.ZodTypeAny {
+  // Basic structure for block content
+  const blockSchema = z.object({
+    _type: z.literal('block'),
+    style: z.string(),
+    markDefs: z
+      .array(
+        z
+          .object({
+            _type: z.string(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    children: z.array(
+      z
+        .object({
+          _type: z.string(),
+          text: z.string().optional(),
+          marks: z.array(z.string()).optional(),
+        })
+        .passthrough(),
+    ),
+  })
+
+  return blockSchema
+}


### PR DESCRIPTION
- validate patches against server-side schema
- add new tool "getDocument" for retrieving a single document. Useful becuase it's able get fallback versions such as a draft when a published version does not exist, and vice versa
- add schema fetch as util