### PR TITLE
fix: add schema for items types in patch insert op. Fixes #40

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       fast-xml-parser:
         specifier: ^5.2.0
         version: 5.2.0
+      get-it:
+        specifier: ^8.3.2
+        version: 8.6.7
       outdent:
         specifier: ^0.8.0
         version: 0.8.0

--- a/src/tools/documents/patchDocumentTool.ts
+++ b/src/tools/documents/patchDocumentTool.ts
@@ -19,13 +19,20 @@ const UnsetOperation = z.object({
   path: z.string().describe('The path to unset, e.g. "description" or "metadata.keywords"'),
 })
 
+const InsertValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.record(z.unknown()),
+]);
+
 const InsertOperation = z.object({
   op: z.literal('insert'),
   position: z.enum(['before', 'after', 'replace']),
   path: z
     .string()
     .describe('The path to the array or element, e.g. "categories" or "categories[0]"'),
-  items: z.array(z.any()).describe('The items to insert'),
+  items: z.array(InsertValueSchema).describe('The items to insert. Array items must be either all primitives or all objects, they can never be mixed in one array.'),
 })
 
 const IncOperation = z.object({


### PR DESCRIPTION
vscode complains about `any` in array schema, see referenced issue for more information