### PR TITLE
feat: remove tagged client, prepare for v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Before you can use the MCP server, you need to:
    npx sanity schema deploy
    ```
 
+   When running in CI environments without Sanity login, you'll need to provide an auth token:
+
+   ```bash
+   SANITY_AUTH_TOKEN=<token> sanity schema deploy
+   ```
+
    > [!NOTE]
    > Schema deployment requires Sanity CLI version 3.88.1 or newer.
 
@@ -162,8 +168,7 @@ The server takes the following environment variables:
 | `SANITY_API_HOST`   | API host (defaults to https://api.sanity.io)       | ❌       |
 | `MCP_USER_ROLE`     | Determines tool access level (developer or editor) | ❌       |
 
-> [!WARNING]  
-> **Using AI with Production Datasets**  
+> [!WARNING] > **Using AI with Production Datasets**
 > When configuring the MCP server with a token that has write access to a production dataset, please be aware that the AI can perform destructive actions like creating, updating, or deleting content. This is not a concern if you're using a read-only token. While we are actively developing guardrails, you should exercise caution and consider using a development/staging dataset for testing AI operations that require write access.
 
 ### 🔑 API Tokens and Permissions

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ Before you can use the MCP server, you need to:
    # Option A: If you have the CLI installed globally
    npm install -g sanity
    cd /path/to/studio
-   SANITY_CLI_SCHEMA_STORE_ENABLED=true sanity schema deploy
+   sanity schema deploy
 
    # Option B: Update your Studio
    cd /path/to/studio
    npm update sanity
-   SANITY_CLI_SCHEMA_STORE_ENABLED=true npx sanity schema deploy
+   npx sanity schema deploy
    ```
 
    > [!NOTE]
-   > Schema deployment requires both the latest CLI version and the SANITY_CLI_SCHEMA_STORE_ENABLED flag. This feature will be enabled by default in a future release.
+   > Schema deployment requires Sanity CLI version 3.88.1 or newer.
 
 2. **Get your API credentials**
    - Project ID

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/mcp-server",
-  "version": "0.7.17",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/sanity-io/sanity-mcp-server"
@@ -26,7 +26,7 @@
   "prettier": "@sanity/prettier-config",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
-    "@sanity/client": "6.29.1-agent-actions.2",
+    "@sanity/client": "7.1.0",
     "@sanity/id-utils": "^1.0.0",
     "chrono-node": "^2.8.0",
     "dotenv": "^16.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.7.0
         version: 1.8.0
       '@sanity/client':
-        specifier: 6.29.1-agent-actions.2
-        version: 6.29.1-agent-actions.2
+        specifier: 7.1.0
+        version: 7.1.0
       '@sanity/id-utils':
         specifier: ^1.0.0
         version: 1.0.0
@@ -148,9 +148,9 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@sanity/client@6.29.1-agent-actions.2':
-    resolution: {integrity: sha512-tjYylnrs/s6UdHdLJM8OESC4w8Y5RiCECNiKSCggNvxwg29Qe7ifKluT/K7QcSWhv52MzfrbJtr0eA9NictBLA==}
-    engines: {node: '>=14.18'}
+  '@sanity/client@7.1.0':
+    resolution: {integrity: sha512-AQ9NV2iXSGKlWFywxT1bnLKUfyq6GnZvY0KJLZiob/12faOoWHXYOF/m1qevpahXaw0le2ytUfCbvwZMYZfH4g==}
+    engines: {node: '>=20'}
 
   '@sanity/eventsource@5.0.2':
     resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
@@ -1226,7 +1226,7 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@sanity/client@6.29.1-agent-actions.2':
+  '@sanity/client@7.1.0':
     dependencies:
       '@sanity/eventsource': 5.0.2
       get-it: 8.6.7

--- a/src/tools/schema/common.ts
+++ b/src/tools/schema/common.ts
@@ -1,7 +1,9 @@
 import {outdent} from 'outdent'
 import {z} from 'zod'
 
-export const DEFAULT_SCHEMA_ID = 'sanity.workspace.schemas.default'
+export const SCHEMA_TYPE = 'system.schema'
+
+export const DEFAULT_SCHEMA_ID = '_.schemas.default'
 
 export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
   Your Sanity schema has not been deployed. In your Sanity project, run the following command:
@@ -12,6 +14,7 @@ export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
 
 export const schemaIdSchema = z
   .string()
+  .regex(/^_\.schemas\..+$/, 'Schema ID must be in the format of `_.schemas.${string}`')
   .optional()
   .default(DEFAULT_SCHEMA_ID)
   .describe(

--- a/src/tools/schema/common.ts
+++ b/src/tools/schema/common.ts
@@ -1,9 +1,10 @@
 import {outdent} from 'outdent'
 import {z} from 'zod'
+import type {SchemaId} from '../../types/sanity.js'
 
 export const SCHEMA_TYPE = 'system.schema'
 
-export const DEFAULT_SCHEMA_ID = '_.schemas.default'
+export const DEFAULT_SCHEMA_ID: SchemaId = '_.schemas.default'
 
 export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
   Your Sanity schema has not been deployed. In your Sanity project, run the following command:

--- a/src/tools/schema/common.ts
+++ b/src/tools/schema/common.ts
@@ -1,7 +1,7 @@
 import {outdent} from 'outdent'
 import {z} from 'zod'
 
-export const DEFAULT_SCHEMA_ID = 'sanity.workspace.schema.default'
+export const DEFAULT_SCHEMA_ID = 'sanity.workspace.schemas.default'
 
 export const SCHEMA_DEPLOYMENT_INSTRUCTIONS = outdent`
   Your Sanity schema has not been deployed. In your Sanity project, run the following command:

--- a/src/tools/schema/getSchemaTool.ts
+++ b/src/tools/schema/getSchemaTool.ts
@@ -28,9 +28,10 @@ type Params = z.infer<typeof GetSchemaToolParams>
 
 async function tool(params: Params) {
   const schemaId = params.schemaId ?? DEFAULT_SCHEMA_ID
-  const schemaDoc = await sanityClient.fetch('*[_id == $schemaId][0]', {
-    schemaId,
-  })
+  const schemaDoc = await sanityClient.fetch(
+    '*[_id == $schemaId && _type == "sanity.workspace.schema"][0]',
+    {schemaId},
+  )
 
   if (!schemaDoc?.schema) {
     return createErrorResponse(SCHEMA_DEPLOYMENT_INSTRUCTIONS)

--- a/src/tools/schema/getSchemaTool.ts
+++ b/src/tools/schema/getSchemaTool.ts
@@ -7,7 +7,12 @@ import {
   createSuccessResponse,
   withErrorHandling,
 } from '../../utils/response.js'
-import {DEFAULT_SCHEMA_ID, SCHEMA_DEPLOYMENT_INSTRUCTIONS, schemaIdSchema} from './common.js'
+import {
+  DEFAULT_SCHEMA_ID,
+  SCHEMA_DEPLOYMENT_INSTRUCTIONS,
+  SCHEMA_TYPE,
+  schemaIdSchema,
+} from './common.js'
 
 export const GetSchemaToolParams = z.object({
   type: z
@@ -28,10 +33,10 @@ type Params = z.infer<typeof GetSchemaToolParams>
 
 async function tool(params: Params) {
   const schemaId = params.schemaId ?? DEFAULT_SCHEMA_ID
-  const schemaDoc = await sanityClient.fetch(
-    '*[_id == $schemaId && _type == "sanity.workspace.schema"][0]',
-    {schemaId},
-  )
+  const schemaDoc = await sanityClient.fetch('*[_id == $schemaId && _type == $schemaType][0]', {
+    schemaType: SCHEMA_TYPE,
+    schemaId,
+  })
 
   if (!schemaDoc?.schema) {
     return createErrorResponse(SCHEMA_DEPLOYMENT_INSTRUCTIONS)

--- a/src/tools/schema/listSchemaIdsTool.ts
+++ b/src/tools/schema/listSchemaIdsTool.ts
@@ -5,16 +5,16 @@ import {
   createErrorResponse,
   withErrorHandling,
 } from '../../utils/response.js'
-import {SCHEMA_DEPLOYMENT_INSTRUCTIONS} from './common.js'
+import {SCHEMA_DEPLOYMENT_INSTRUCTIONS, SCHEMA_TYPE} from './common.js'
 
 export const ListSchemaIdsToolParams = z.object({})
 
 type Params = z.infer<typeof ListSchemaIdsToolParams>
 
 async function tool(_params?: Params) {
-  const schemas = await sanityClient.fetch<{_id: string}[]>(
-    '*[_type == "sanity.workspace.schema"]{ _id }',
-  )
+  const schemas = await sanityClient.fetch<{_id: string}[]>('*[_type == $schemaType]{ _id }', {
+    schemaType: SCHEMA_TYPE,
+  })
 
   if (!schemas || schemas.length === 0) {
     return createErrorResponse(SCHEMA_DEPLOYMENT_INSTRUCTIONS)

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -65,3 +65,5 @@ export interface Release {
   finalDocumentStates: Array<{id: string; _key?: string}> | null
   userId: string
 }
+
+export type SchemaId = `_.schemas.${string}`


### PR DESCRIPTION
- Removed tagged client
- Removed mention of SANITY_CLI_SCHEMA_STORE_ENABLED flag in README.md, replaced with minimum version requirement. 
- Schema id prefix has changed to `sanity.workspace.schemas.` from `sanity.workspace.schema.` 