### PR TITLE
Add missing MCP_USER_ROLE to README configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To use the Sanity MCP server, add the following configuration to your applicatio
       "env": {
         "SANITY_PROJECT_ID": "your-project-id",
         "SANITY_DATASET": "production",
-        "SANITY_API_TOKEN": "your-sanity-api-token"
+        "SANITY_API_TOKEN": "your-sanity-api-token",
+        "MCP_USER_ROLE": "developer"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ To use the Sanity MCP server, add the following configuration to your applicatio
 }
 ```
 
+For a complete list of all required and optional environment variables, see the [Configuration section](#️-configuration).
+
 The exact location of this configuration will depend on your application:
 
 | Application    | Configuration Location                            |


### PR DESCRIPTION
This PR addresses a documentation inconsistency where the sample configuration was missing the required `MCP_USER_ROLE` environment variable. Changes include:

1. Added the missing `MCP_USER_ROLE` to the JSON configuration example
2. Added a link to the Configuration section for reference

These changes ensure the documentation is consistent and help users set up the server correctly from the start.
