### PR TITLE
feat - tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ sudo rm /usr/local/bin/node /usr/local/bin/npx
 Remove-Item "C:\Program Files\nodejs\node.exe", "C:\Program Files\nodejs\npx.cmd"
 ```
 
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/tools/releases/releaseActionsTool.ts
+```
 ## 💻 Development
 
 Install dependencies:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "get-it": "^8.3.2",
     "groq-js": "^1.16.1",
     "outdent": "^0.8.0",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "mcp-evals": "^1.0.18"
   },
   "devDependencies": {
     "@sanity/prettier-config": "^1.0.3",

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const releaseActionsToolEval: EvalFunction = {
+    name: 'Release Actions Tool Evaluation',
+    description: 'Evaluates the release actions tool for creating and managing releases',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Create a new major release with version 2.0.0 and add release notes highlighting the critical improvements.");
+        return JSON.parse(result);
+    }
+};
+
+const listReleasesToolEvaluation: EvalFunction = {
+    name: 'listReleasesToolEvaluation',
+    description: 'Evaluates the listReleasesTool by verifying it lists repository releases from the past month',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "List all the releases for the GitHub repository 'microsoft/vscode' created in the past month");
+        return JSON.parse(result);
+    }
+};
+
+const editReleaseToolEval: EvalFunction = {
+    name: 'editReleaseToolEval',
+    description: 'Evaluates the edit release tool functionality',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please edit the release with ID 123 to change its version to 2.3.4 and add the note: 'Minor bug fixes and improvements.'");
+        return JSON.parse(result);
+    }
+};
+
+const list_releasesEval: EvalFunction = {
+    name: 'list_releases Evaluation',
+    description: 'Evaluates the list_releases tool',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Show me the scheduled content releases available in Sanity");
+        return JSON.parse(result);
+    }
+};
+
+const create_releaseEval: EvalFunction = {
+    name: 'create_release',
+    description: 'Evaluates the creation of a new content release in Sanity with an automatically generated ID',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Create a new content release named 'Summer Release' in Sanity with an automatically generated ID.");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [releaseActionsToolEval, listReleasesToolEvaluation, editReleaseToolEval, list_releasesEval, create_releaseEval]
+};
+  
+export default config;
+  
+export const evals = [releaseActionsToolEval, listReleasesToolEvaluation, editReleaseToolEval, list_releasesEval, create_releaseEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 