### PR TITLE
Add hosted mcp server info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Sanity MCP Server implements the [Model Context Protocol](https://modelcontextpr
 - [🔌 Quickstart](#-quickstart)
   - [Prerequisites](#prerequisites)
   - [Add configuration for the Sanity MCP server](#add-configuration-for-the-sanity-mcp-server)
+- [🌐 Hosted Version (Recommended)](#-hosted-version-recommended)
 - [🛠️ Available Tools](#️-available-tools)
 - [⚙️ Configuration](#️-configuration)
   - [🔑 API Tokens and Permissions](#-api-tokens-and-permissions)
@@ -104,6 +105,46 @@ The exact location of this configuration will depend on your application:
 | Custom Apps    | Refer to your app's MCP integration docs          |
 
 You don't get it to work? See the section on [Node.js configuration](#-nodejs-environment-setup).
+
+## 🌐 Hosted Version (Recommended)
+
+For the easiest setup experience, we recommend using the hosted version of the Sanity MCP Server. This eliminates the need for local Node.js configuration and provides a more reliable connection to your Sanity content.
+
+### One-click install in Cursor
+
+Click the link below to automatically install the hosted Sanity MCP Server in Cursor:
+
+[**Install Sanity Developer MCP Server**](<cursor://anysphere.cursor-deeplink/mcp/install?name=Sanity%20Developer&config=eyJ1cmwiOiJodHRwczovL21jcC5zYW5pdHkuaW8vZGV2ZWxvcGVyIiwidHlwZSI6Imh0dHAifQ%3D%3D>)
+
+This will automatically configure the hosted MCP server in your Cursor environment. You'll still need to provide your Sanity project credentials (Project ID, Dataset, and API Token) as environment variables.
+
+### Benefits of the Hosted Version
+
+- ✅ **No Node.js setup required** - Eliminates version management issues
+- ✅ **Always up-to-date** - Automatically uses the latest server version
+- ✅ **Better reliability** - Managed infrastructure with high availability
+- ✅ **Simplified configuration** - Fewer moving parts to troubleshoot
+
+### Manual Configuration for Other Tools
+
+If you're not using Cursor or prefer manual configuration, you can set up the hosted version by adding this to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "sanity": {
+      "url": "https://mcp.sanity.io/developer",
+      "type": "http",
+      "env": {
+        "SANITY_PROJECT_ID": "your-project-id",
+        "SANITY_DATASET": "production",
+        "SANITY_API_TOKEN": "your-sanity-api-token",
+        "MCP_USER_ROLE": "developer"
+      }
+    }
+  }
+}
+```
 
 ## 🛠️ Available Tools
 


### PR DESCRIPTION
Add a section to the README about the hosted Sanity MCP server, including a one-click Cursor install link, to promote the recommended, easier-to-use version.

The hosted version was recently launched and offers a simpler setup by eliminating Node.js configuration complexities, which was a point of friction for users. This update makes the recommended installation method more discoverable and accessible directly from the README.

---
[Slack Thread](https://sanity-io.slack.com/archives/CB92H8WJ0/p1755873004823769?thread_ts=1755873004.823769&cid=CB92H8WJ0)

<a href="https://cursor.com/background-agent?bcId=bc-e0d4886f-f67d-4747-927f-f1cdd4dec40f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0d4886f-f67d-4747-927f-f1cdd4dec40f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

